### PR TITLE
Centralize Version Numbers

### DIFF
--- a/Android/SharedCode/build.gradle
+++ b/Android/SharedCode/build.gradle
@@ -14,11 +14,11 @@ kotlin {
     jvm("android")
 
     sourceSets.commonMain.dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib-common"
+        implementation deps.kotlin.stdlib.common
     }
 
     sourceSets.androidMain.dependencies {
-        implementation "org.jetbrains.kotlin:kotlin-stdlib"
+        implementation deps.kotlin.stdlib.jdk
     }
 }
 

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -6,7 +6,6 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.0"
     defaultConfig {
         applicationId "com.example.players"
         minSdkVersion 23
@@ -25,12 +24,10 @@ android {
 
 dependencies {
     implementation project(':SharedCode')
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'androidx.core:core-ktx:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -1,15 +1,26 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+
+    ext.versions = [
+            'kotlin': '1.3.50',
+    ]
+    ext.deps = [
+            'kotlin': [
+                    'stdlib': [
+                            'common': "org.jetbrains.kotlin:kotlin-stdlib-common:${versions.kotlin}",
+                            'jdk'   : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
+                    ]
+            ]
+    ]
     repositories {
         google()
         jcenter()
-        
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -19,7 +30,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 


### PR DESCRIPTION
Put version numbers and deps all in one spot.  Will be used for all KMP dependencies.  Also some misc gradle cleanups.