### PR TITLE
Convert JVM to Android

### DIFF
--- a/Android/.idea/misc.xml
+++ b/Android/.idea/misc.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/Android/SharedCode/build.gradle
+++ b/Android/SharedCode/build.gradle
@@ -1,8 +1,12 @@
 apply plugin: 'kotlin-multiplatform'
+apply plugin: 'com.android.library'
+apply from: "$rootProject.projectDir/common-android.gradle"
 
 kotlin {
-    //select iOS target platform depending on the Xcode environment variables
     targets {
+        android()
+
+        //select iOS target platform depending on the Xcode environment variables
         def iosPreset = System.getenv('SDK_NAME')?.startsWith("iphoneos") ? presets.iosArm64 : presets.iosX64
         fromPreset(iosPreset, 'ios') {
             binaries.framework {
@@ -10,8 +14,6 @@ kotlin {
             }
         }
     }
-
-    jvm("android")
 
     sourceSets.commonMain.dependencies {
         implementation deps.kotlin.stdlib.common

--- a/Android/SharedCode/src/main/AndroidManifest.xml
+++ b/Android/SharedCode/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.example.players.SharedCode" />

--- a/Android/app/build.gradle
+++ b/Android/app/build.gradle
@@ -1,19 +1,9 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
 
+apply from: "$rootProject.projectDir/common-android.gradle"
 android {
-    compileSdkVersion 29
-    defaultConfig {
-        applicationId "com.example.players"
-        minSdkVersion 23
-        targetSdkVersion 29
-        versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
     buildTypes {
         release {
             minifyEnabled false

--- a/Android/common-android.gradle
+++ b/Android/common-android.gradle
@@ -1,0 +1,16 @@
+android {
+    compileSdkVersion 29
+
+    defaultConfig {
+        minSdkVersion 23
+        targetSdkVersion 29
+        versionCode 1
+        versionName "1.0.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}


### PR DESCRIPTION
Convert JVM shared module to Android as we believe it is needed for LiveData and networking code.